### PR TITLE
Merge custom install profiles

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,8 +6,7 @@
     "require": {
         "symfony/filesystem": "~2.1",
         "symfony/finder": "~2.1",
-        "symfony/console": "~2.3",
-        "composer/composer": "~1.0@alpha"
+        "symfony/console": "~2.3"
     },
 
     "require-dev": {

--- a/src/Rootcanal/Config/Config.php
+++ b/src/Rootcanal/Config/Config.php
@@ -59,6 +59,7 @@ class Config
         $destination,
         $modulePath,
         $themePath,
+        $libraryPath,
         $drushPath,
         $profilePath,
         $filesPublicPath,
@@ -70,6 +71,7 @@ class Config
         $this->destination      = $this->getDestination($destination);
         $this->modulePath       = $modulePath;
         $this->themePath        = $themePath;
+        $this->libraryPath      = $libraryPath;
         $this->drushPath        = $drushPath;
         $this->profilePath      = $profilePath;
         $this->filesPublicPath  = $filesPublicPath;
@@ -98,6 +100,7 @@ class Config
             'module'        => $this->destination . $this->modulePath,
             'custom'        => $this->destination . $this->modulePath . '/%s',
             'theme'         => $this->destination . $this->themePath,
+            'librarie'      => $this->destination . $this->libraryPath,
             'drush'         => $this->destination . $this->drushPath,
             'profile'       => $this->destination . $this->profilePath,
             'files-public'  => $this->destination . $this->filesPublicPath,

--- a/src/Rootcanal/Console/Command.php
+++ b/src/Rootcanal/Console/Command.php
@@ -118,6 +118,7 @@ EOF
             $input->getOption('destination'),
             '/sites/all/modules/%s',
             '/sites/all/themes/%s',
+            '/sites/all/libraries/%s',
             '/sites/all/drush/%s',
             '/profiles/%s',
             '/sites/default/files',

--- a/src/Rootcanal/Mapper.php
+++ b/src/Rootcanal/Mapper.php
@@ -75,6 +75,7 @@ class Mapper
             $this->mapCustomByType('profile'),
             $this->mapCustomByType('module'),
             $this->mapCustomByType('theme'),
+            $this->mapCustomByType('librarie'),
             $this->mapCustomFiles(),
             $this->mapVendor(),
             $this->mapSettings(),

--- a/src/Rootcanal/Mapper.php
+++ b/src/Rootcanal/Mapper.php
@@ -72,6 +72,7 @@ class Mapper
     {
         return array_merge(
             $this->mapContrib(),
+            $this->mapCustomByType('profile'),
             $this->mapCustomByType('module'),
             $this->mapCustomByType('theme'),
             $this->mapCustomFiles(),


### PR DESCRIPTION
Only custom code located in ./modules and ./themes was being included in the build. This change adds support for custom install profile code located in ./profiles using the same mechanism.
